### PR TITLE
Fixes toggletip rendering in Safari

### DIFF
--- a/src/site/_includes/js/accessibility.js
+++ b/src/site/_includes/js/accessibility.js
@@ -44,6 +44,7 @@
       // Create the live region
       let liveRegion = document.createElement('span');
       liveRegion.setAttribute('role', 'status');
+      liveRegion.setAttribute('class', 'toggletip_container');
       
       // Place the live region in the container
       container.appendChild(liveRegion);

--- a/src/site/_includes/type.scss
+++ b/src/site/_includes/type.scss
@@ -239,11 +239,15 @@
     display: inline-block;
   }
 
+  .toggletip_container {
+    position: absolute;
+    width: 20em;
+  }
+
   .toggletip_content,
   .tooltip_content {
     min-width: 10em;
     max-width: 20em;
-    width: max-content;
     background-color: var(--color-gray-200);
     color: var(--color-white);
     text-align: center;
@@ -254,8 +258,8 @@
     border-color: var(--color-white);
     position: absolute;
     z-index: 1;
-    top: -5px;
-    left: 105%;
+    top: -0.3em;
+    left: 0.3em;
   }
 
   /* Extra area to prevent the toggletip disappearing


### PR DESCRIPTION
extra linebreaks had previously been added in the max income toggletip when viewing with Safari.