### PR TITLE
Treats empty POPULATIONS_SERVED as General Population

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -489,6 +489,12 @@ module.exports = function(eleventyConfig) {
       // See https://community.airtable.com/t/return-rows-that-contain-multiple-select-item/42187/4
       // for a complicated solution.
       let populationsQuery = populations.map(x => `FIND('${x}', {_POPULATIONS_SERVED})`);
+      if (populations.includes("General Population")) {
+        // Entries with an empty _POPULATIONS_SERVED field are interpreted as
+        // being open to the general public, so allow those entries as well if
+        // the user wants General Population entries.
+        populationsQuery.push("{_POPULATIONS_SERVED} = BLANK()");
+      }
       parameters.push(`OR(${populationsQuery.join(",")})`);
     }
 

--- a/netlify/functions/units.js
+++ b/netlify/functions/units.js
@@ -364,7 +364,7 @@ const fetchData = async(housingID) => {
         units.metadata["Website"] = (
           records[0].fields["_PROPERTY_URL"]?.[0]|| "");
         units.metadata.notesData["_POPULATIONS_SERVED"] = (
-          records[0].fields["_POPULATIONS_SERVED"]);
+          records[0].fields["_POPULATIONS_SERVED"] || []);
         units.metadata.notesData["_MIN_RESIDENT_AGE"] = (
           records[0].fields["_MIN_RESIDENT_AGE"]?.[0]|| "");
         units.metadata.notesData["_MAX_RESIDENT_AGE"] = (


### PR DESCRIPTION
Fixes an issue where the units function would crash if the `POPULATIONS_SERVED` Airtable field was left blank.