### PR TITLE
Fixes initial apartment highlighting bug.

### DIFF
--- a/src/site/_includes/js/affordable-housing-map.js
+++ b/src/site/_includes/js/affordable-housing-map.js
@@ -219,7 +219,7 @@
   }
 
   // Initializes the map's surrounding interface and sets up relevant listeners.
-  function initInterface(interface, markers) {
+  function initInterface(interface, map, markers) {
     // Show the map, toggle button, and interactive list item map links since 
     // javascript is working.
     if (markers.length > 0) {
@@ -237,6 +237,11 @@
       extMapLink.classList.add("hidden");
 
       showMapButton.addEventListener("click", () => {
+        // On page load, there is a bounds_changed listener that helps
+        // set the initial map bounds properly if the map is hidden.  Make sure
+        // that listener is not active before highlighting the marker so
+        // the map can zoom and pan uninterrupted.
+        google.maps.event.clearListeners(map, 'bounds_changed');
         google.maps.event.trigger(marker, "click", null, true);
         switchToMapView(interface);
         interface.toggleButton.scrollIntoView();
@@ -281,7 +286,7 @@
 
     const legend = addLegend(map, smallTransitMarkerOpts.icon);
 
-    initInterface(interface, aptMarkers);
+    initInterface(interface, map, aptMarkers);
 
     let prevZoom = 0;
     google.maps.event.addListener(map, 'zoom_changed', () => {


### PR DESCRIPTION
If the map was hidden on page load and the user clicked on a "Show on map" link, the map appeared but did not zoom into the apartment.