### PR TITLE
Caches housing data for faster filtering performance

### DIFF
--- a/src/site/_data/housing.js
+++ b/src/site/_data/housing.js
@@ -152,7 +152,22 @@ const fetchHousingList = async() => {
           });
         }
       });
-      return housingList;
+
+      let housingById = {};
+      // TODO: change loop to "for of"
+      for (const idx in housingList) {
+        let housingId = housingList[idx].id;
+        housingById[housingId] = housingById[housingId] || housingList[idx];
+        housingById[housingId].units.push(housingList[idx].unit);
+        // The 'unit' property was temporary and used only to hold
+        // the unit-level data for each fetched record.  The same data
+        // (plus data for other units with the same housing ID)
+        // now resides in the 'units' property.
+        delete housingById[housingId].unit;
+      }
+      // Each housing ID key is also stored in the value as the 'id' property
+      // so the object can be converted to an array without information loss.
+      return Object.values(housingById);
     });
 }
 
@@ -168,6 +183,7 @@ const housingData = async() => {
 // having a unique list of FilterCheckboxes encompassing all the values
 // available in the Airtable data at that time.
 module.exports = async function() {
+  
   const asset = new AssetCache("affordable_housing_data");
   // This cache duration will only be used at build time.
   let cacheDuration = "1d";
@@ -184,7 +200,7 @@ module.exports = async function() {
 
   const filterVals = await filterOptions();
   const housing = await housingData();
-  
+
   let data = {filterValues: filterVals, housingList: housing};
 
   await asset.save(data, "json");

--- a/src/site/serverless/affordable-housing-feed.liquid
+++ b/src/site/serverless/affordable-housing-feed.liquid
@@ -5,5 +5,5 @@ permalink:
   serverless: "/data/housing/affordable-housing/filter"
 ---
 {% assign query = eleventy.serverless.query %}
-{% assign housingdb = query | housingResults %}
+{% assign housingdb = housingList | groupUnits %}
 {{ housingdb | json }}

--- a/src/site/serverless/affordable-housing-feed.liquid
+++ b/src/site/serverless/affordable-housing-feed.liquid
@@ -5,5 +5,5 @@ permalink:
   serverless: "/data/housing/affordable-housing/filter"
 ---
 {% assign query = eleventy.serverless.query %}
-{% assign housingdb = housingList | groupUnits %}
+{% assign housingdb = housing.housingList | filterByQuery: query %}
 {{ housingdb | json }}

--- a/src/site/serverless/affordable-housing-table.liquid
+++ b/src/site/serverless/affordable-housing-table.liquid
@@ -9,7 +9,7 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
 ---
 
 {% assign query = eleventy.serverless.query %}
-{% assign housingdb = housingList | groupUnits %}
+{% assign housingdb = housing.housingList | filterByQuery: query %}
 {% assign numFiltersApplied = query | numFiltersApplied %}
 {% assign numResults = housingdb | size %}
 

--- a/src/site/serverless/affordable-housing-table.liquid
+++ b/src/site/serverless/affordable-housing-table.liquid
@@ -9,7 +9,7 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
 ---
 
 {% assign query = eleventy.serverless.query %}
-{% assign housingdb = query | housingResults %}
+{% assign housingdb = housingList | groupUnits %}
 {% assign numFiltersApplied = query | numFiltersApplied %}
 {% assign numResults = housingdb | size %}
 

--- a/src/site/serverless/affordable-housing-tracker.liquid
+++ b/src/site/serverless/affordable-housing-tracker.liquid
@@ -8,7 +8,7 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
 ---
 
 {% assign query = eleventy.serverless.query %}
-{% assign housingdb = query | housingResults %}
+{% assign housingdb = housingList | groupUnits %}
 {% assign numFiltersApplied = query | numFiltersApplied %}
 {% assign numResults = housingdb | size %}
 

--- a/src/site/serverless/affordable-housing-tracker.liquid
+++ b/src/site/serverless/affordable-housing-tracker.liquid
@@ -8,7 +8,7 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
 ---
 
 {% assign query = eleventy.serverless.query %}
-{% assign housingdb = housingList | groupUnits %}
+{% assign housingdb = housing.housingList | filterByQuery: query %}
 {% assign numFiltersApplied = query | numFiltersApplied %}
 {% assign numResults = housingdb | size %}
 
@@ -48,12 +48,13 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
   <p>Filters Applied:<br/> {% querySummary query %}</p>
 {% endif %}
 
+{% comment %} TODO: actually check results for closed waitlists {% endcomment %}
 {% if query.availability == nil or query.availability == "" or query.availability contains "Waitlist Closed" %}
-  {% assign availabilities = filterValues | where: "name", "availability" %}
+  {% assign availabilities = housing.filterValues | where: "name", "availability" %}
   {% assign availabilities = availabilities[0].options | map: "name" %}
   {% assign newQuery = query | removeWaitlistClosed: availabilities %}
   <p class="note">
-    {% assign includesStr = "includes some" %}
+    {% assign includesStr = "may include some" %}
     {% assign linkStr = "Hide properties with a closed waitlist" %}
     {% if query.availability == "Waitlist Closed" %}
       {% assign includesStr = "only contains" %}

--- a/src/site/serverless/affordable-housing.liquid
+++ b/src/site/serverless/affordable-housing.liquid
@@ -14,7 +14,7 @@ pageHead: '<script src="/js/accessibility.js" defer></script>
 {% assign updateButtonStr = "Update results" %}
 {% assign query = eleventy.serverless.query %}
 {% assign summaryProps = "unitType,openStatus" | split: "," %}
-{% assign housingdb = housingList | filterByQuery: query | groupUnits | summarizeUnits: summaryProps %}
+{% assign housingdb = housing.housingList | filterByQuery: query | summarizeUnits: summaryProps %}
 {% assign num_results = housingdb | size %}
 {% assign num_filters_applied = query | numFiltersApplied %}
 {% capture num_results_snippet %}
@@ -109,7 +109,7 @@ Narrow your search with the filter options below or <a href="#results">scroll</a
 <section aria-label="Housing Filter Options">
 <form action="/housing/affordable-housing/filter" action="get" id="housing-search" class="housing_search" onsubmit="ShowLoading();">
   
-  {% assign filterValues = filterValues | updateFilterState: query %}
+  {% assign filterValues = housing.filterValues | updateFilterState: query %}
 
   {% for section in filterValues %}
   <fieldset>

--- a/src/site/serverless/affordable-housing.liquid
+++ b/src/site/serverless/affordable-housing.liquid
@@ -13,7 +13,7 @@ pageHead: '<script src="/js/accessibility.js" defer></script>
 {% assign updateButtonStr = "Update results" %}
 {% assign query = eleventy.serverless.query %}
 {% assign summaryProps = "unitType,openStatus" | split: "," %}
-{% assign housingdb = query | housingResults | summarizeUnits: summaryProps %}
+{% assign housingdb = housingList | groupUnits | summarizeUnits: summaryProps %}
 {% assign num_results = housingdb | size %}
 {% assign num_filters_applied = query | numFiltersApplied %}
 {% capture num_results_snippet %}

--- a/src/site/serverless/affordable-housing.liquid
+++ b/src/site/serverless/affordable-housing.liquid
@@ -10,10 +10,11 @@ pageHead: '<script src="/js/accessibility.js" defer></script>
   <script src="/js/affordable-housing-map.js" defer></script>
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA17udd4ePocbxKrOkHiMhSUHlvf3daZMs&callback=initMap&v=weekly" defer></script>'
 ---
+
 {% assign updateButtonStr = "Update results" %}
 {% assign query = eleventy.serverless.query %}
 {% assign summaryProps = "unitType,openStatus" | split: "," %}
-{% assign housingdb = housingList | groupUnits | summarizeUnits: summaryProps %}
+{% assign housingdb = housingList | filterByQuery: query | groupUnits | summarizeUnits: summaryProps %}
 {% assign num_results = housingdb | size %}
 {% assign num_filters_applied = query | numFiltersApplied %}
 {% capture num_results_snippet %}

--- a/src/site/serverless/serverless.11tydata.js
+++ b/src/site/serverless/serverless.11tydata.js
@@ -145,6 +145,10 @@ const fetchHousingList = async() => {
             email: record.get("_EMAIL")?.[0] || "",
             populationsServed: record.get("_POPULATIONS_SERVED"),
             minAge: record.get("_MIN_RESIDENT_AGE"),
+            disallowsPublicApps: record.get(
+              "_DISALLOWS_PUBLIC_APPLICATIONS")?.[0] || false,
+            hasWheelchairAccessibleUnits: record.get(
+              "_HAS_WHEELCHAIR_ACCESSIBLE_UNITS")?.[0] || false,
           });
         }
       });


### PR DESCRIPTION
The affordable housing search page is still rendered using eleventy serverless, but now no Airtable requests are made to do so.  Affordable housing data is fetched at build time and persisted until the next build via caching.

This also means that changes to Airtable data will not immediately be visible on the live production site.

First part of merging in the functionality of #139 